### PR TITLE
Bring latest changes from action_delegator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "decidim", "0.21.0"
 gem "decidim-consultations", "0.21.0"
 # gem "decidim-initiatives", "0.21.0"
 
-gem "decidim-action_delegator", github: "coopdevs/decidim-module-action_delegator", branch: "admin-delegations-ui"
+gem "decidim-action_delegator", github: "coopdevs/decidim-module-action_delegator"
 
 gem "bootsnap", "~> 1.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: git://github.com/coopdevs/decidim-module-action_delegator.git
-  revision: 67abc51c516ee6ba78c835f270493d862e00b1ec
-  branch: admin-delegations-ui
+  revision: 492f145d10abb886e1ebcdaaca0f52900ba2cc8a
   specs:
     decidim-action_delegator (0.1)
       decidim-admin (= 0.21.0)

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec passenger start -p ${PORT:-3000} --max-pool-size ${WEB_CONCURRENCY:-5}
 worker: bundle exec sidekiq -e ${RACK_ENV:-development} -C config/sidekiq.yml
-release: bundle exec rails decidim_action_delegator:install:migrations && bundle exec rake db:migrate
+release: bundle exec rake db:migrate

--- a/db/migrate/20200908124202_create_decidim_consultations.decidim_consultations.rb
+++ b/db/migrate/20200908124202_create_decidim_consultations.decidim_consultations.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180109092205)
+
+class CreateDecidimConsultations < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_consultations do |t|
+      t.string :slug, null: false
+      t.integer :decidim_organization_id,
+                foreign_key: true,
+                index: {
+                  name: "index_decidim_consultations_on_decidim_organization_id"
+                }
+
+      t.index [:decidim_organization_id, :slug],
+              name: "index_unique_consultation_slug_and_organization",
+              unique: true
+
+      t.jsonb :title, null: false
+      t.jsonb :subtitle, null: false
+      t.jsonb :description, null: false
+
+      # Text search indexes for consultations.
+      t.index :title, name: "decidim_consultations_title_search"
+      t.index :subtitle, name: "decidim_consultations_subtitle_search"
+      t.index :description, name: "decidim_consultations_description_search"
+
+      t.string :banner_image
+      t.string :introductory_video_url
+      t.date :start_voting_date, null: false
+      t.integer :decidim_highlighted_scope_id, index: true
+
+      # Publicable
+      t.datetime :published_at, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200908124203_create_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124203_create_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180112053247)
+
+class CreateDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_consultations_questions do |t|
+      t.references :decidim_consultation, index: { name: "index_consultations_questions_on_consultation_id" }
+      t.references :decidim_scope
+
+      t.jsonb :title, null: false
+      t.jsonb :subtitle, null: false
+      t.jsonb :what_is_decided, null: false
+      t.jsonb :promoter_group, null: false
+      t.jsonb :participatory_scope, null: false
+      t.jsonb :question_context
+
+      # Text search indexes for consultation questions.
+      t.index :title, name: "consultation_questions_title_search"
+      t.index :subtitle, name: "consultation_questions_subtitle_search"
+      t.index :what_is_decided, name: "consultation_questions_what_is_decided_search"
+      t.index :promoter_group, name: "consultation_question_promoter_group_search"
+      t.index :participatory_scope, name: "consultation_question_participatory_scope_search"
+      t.index :question_context, name: "consultation_question_context_search"
+
+      t.string :banner_image
+      t.string :introductory_video_url
+      t.string :reference
+      t.string :hashtag
+
+      # Publicable
+      t.datetime :published_at, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200908124204_add_end_voting_date_to_decidim_consultations.decidim_consultations.rb
+++ b/db/migrate/20200908124204_add_end_voting_date_to_decidim_consultations.decidim_consultations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180115132000)
+
+class AddEndVotingDateToDecidimConsultations < ActiveRecord::Migration[5.1]
+  class Consultation < ApplicationRecord
+    self.table_name = :decidim_consultations
+  end
+
+  def change
+    add_column :decidim_consultations, :end_voting_date, :date
+
+    Consultation.find_each do |consultation|
+      consultation.end_voting_date = consultation.start_voting_date + 1.month
+      consultation.save
+    end
+
+    change_column_null :decidim_consultations, :end_voting_date, false
+  end
+end

--- a/db/migrate/20200908124205_add_slug_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124205_add_slug_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180115170933)
+
+class AddSlugToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  class Question < ApplicationRecord
+    self.table_name = :decidim_consultations_questions
+  end
+
+  def change
+    add_column :decidim_consultations_questions,
+               :decidim_organization_id,
+               :integer,
+               index: {
+                 name: "index_decidim_questions_on_decidim_organization_id"
+               }
+
+    add_column :decidim_consultations_questions, :slug, :string
+
+    Question.find_each do |question|
+      question.decidim_organization_id = question.consultation.decidim_organization_id
+      question.slug = "q-#{question.id}"
+      question.save
+    end
+
+    change_column_null :decidim_consultations_questions, :decidim_organization_id, false
+    change_column_null :decidim_consultations_questions, :slug, false
+
+    add_index :decidim_consultations_questions,
+              [:decidim_organization_id, :slug],
+              name: "index_unique_question_slug_and_organization",
+              unique: true
+  end
+end

--- a/db/migrate/20200908124206_create_decidim_consultations_votes.decidim_consultations.rb
+++ b/db/migrate/20200908124206_create_decidim_consultations_votes.decidim_consultations.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180119084217)
+
+class CreateDecidimConsultationsVotes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_consultations_votes do |t|
+      t.references :decidim_consultation_question, index: { name: "index_consultations_votes_on_consultation_question" }
+      t.references :decidim_author, index: { name: "index_consultations_votes_on_author" }
+
+      t.timestamps
+    end
+
+    add_index :decidim_consultations_votes,
+              [:decidim_consultation_question_id, :decidim_author_id],
+              unique: true,
+              name: "index_question_votes_author_unique"
+  end
+end

--- a/db/migrate/20200908124207_add_votes_count_to_decidim_consultations_question.decidim_consultations.rb
+++ b/db/migrate/20200908124207_add_votes_count_to_decidim_consultations_question.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180119084331)
+
+class AddVotesCountToDecidimConsultationsQuestion < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :votes_count, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20200908124208_add_origin_scope_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124208_add_origin_scope_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180122113155)
+
+class AddOriginScopeToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :origin_scope, :jsonb
+    add_index :decidim_consultations_questions, :origin_scope, name: "consultation_questions_origin_scope_search"
+  end
+end

--- a/db/migrate/20200908124209_add_origin_title_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124209_add_origin_title_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180122113400)
+
+class AddOriginTitleToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :origin_title, :jsonb
+    add_index :decidim_consultations_questions, :origin_title, name: "consultation_questions_origin_title_search"
+  end
+end

--- a/db/migrate/20200908124210_add_origin_string_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124210_add_origin_string_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180122113447)
+
+class AddOriginStringToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :origin_url, :string
+  end
+end

--- a/db/migrate/20200908124211_add_enable_highlighted_banner_to_decidim_consultations.decidim_consultations.rb
+++ b/db/migrate/20200908124211_add_enable_highlighted_banner_to_decidim_consultations.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180126142459)
+
+class AddEnableHighlightedBannerToDecidimConsultations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations, :enable_highlighted_banner, :boolean, null: false, default: true
+  end
+end

--- a/db/migrate/20200908124212_add_i_frame_url_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124212_add_i_frame_url_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180129063438)
+
+class AddIFrameUrlToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :i_frame_url, :string
+    add_column :decidim_consultations_questions, :external_voting, :boolean
+  end
+end

--- a/db/migrate/20200908124213_create_decidim_consultations_responses.decidim_consultations.rb
+++ b/db/migrate/20200908124213_create_decidim_consultations_responses.decidim_consultations.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180129063700)
+
+class CreateDecidimConsultationsResponses < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decidim_consultations_responses do |t|
+      t.jsonb :title
+      t.references :decidim_consultations_questions,
+                   foreign_key: true,
+                   index: { name: "index_consultations_responses_on_consultation_questions" }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200908124214_rename_decidim_consultations_vote_to_decidim_consultations_endorsement.decidim_consultations.rb
+++ b/db/migrate/20200908124214_rename_decidim_consultations_vote_to_decidim_consultations_endorsement.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180129122226)
+
+class RenameDecidimConsultationsVoteToDecidimConsultationsEndorsement < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :decidim_consultations_votes, :decidim_consultations_endorsements
+  end
+end

--- a/db/migrate/20200908124215_rename_decidim_consultations_questions_votes_count_to_endorsements_count.decidim_consultations.rb
+++ b/db/migrate/20200908124215_rename_decidim_consultations_questions_votes_count_to_endorsements_count.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180129122504)
+
+class RenameDecidimConsultationsQuestionsVotesCountToEndorsementsCount < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :decidim_consultations_questions, :votes_count, :endorsements_count
+  end
+end

--- a/db/migrate/20200908124216_add_responses_count_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124216_add_responses_count_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180130060754)
+
+class AddResponsesCountToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :responses_count, :integer, null: false, default: 0
+
+    reversible do |dir|
+      dir.up { initialize_counter }
+    end
+  end
+
+  def initialize_counter
+    execute <<-SQL.squish
+      UPDATE decidim_consultations_questions
+         SET responses_count = (
+           select count(1)
+           from decidim_consultations_responses
+           where decidim_consultations_questions_id = decidim_consultations_questions.id
+         )
+    SQL
+  end
+end

--- a/db/migrate/20200908124217_rename_vote_related_attributes.decidim_consultations.rb
+++ b/db/migrate/20200908124217_rename_vote_related_attributes.decidim_consultations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180130110449)
+
+class RenameVoteRelatedAttributes < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :decidim_consultations, :start_voting_date, :start_endorsing_date
+    rename_column :decidim_consultations, :end_voting_date, :end_endorsing_date
+    rename_column :decidim_consultations_questions, :external_voting, :external_endorsement
+  end
+end

--- a/db/migrate/20200908124218_add_decidim_user_group_id_to_decidim_consultations_endorsements.decidim_consultations.rb
+++ b/db/migrate/20200908124218_add_decidim_user_group_id_to_decidim_consultations_endorsements.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180130142018)
+
+class AddDecidimUserGroupIdToDecidimConsultationsEndorsements < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_endorsements, :decidim_user_group_id, :integer, index: true
+  end
+end

--- a/db/migrate/20200908124219_rename_vote_indexes_to_endorsement_indexes.decidim_consultations.rb
+++ b/db/migrate/20200908124219_rename_vote_indexes_to_endorsement_indexes.decidim_consultations.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180130142411)
+
+class RenameVoteIndexesToEndorsementIndexes < ActiveRecord::Migration[5.1]
+  def change
+    rename_index :decidim_consultations_endorsements,
+                 :index_consultations_votes_on_author,
+                 :index_consultations_endorsements_on_author
+
+    rename_index :decidim_consultations_endorsements,
+                 :index_consultations_votes_on_consultation_question,
+                 :index_consultations_endorsements_on_consultation_question
+
+    reversible do |dir|
+      dir.up { create_authorable_unique }
+      dir.down { create_author_unique }
+    end
+  end
+
+  def create_authorable_unique
+    remove_index :decidim_consultations_endorsements, name: "index_question_votes_author_unique"
+
+    add_index :decidim_consultations_endorsements,
+              %w(decidim_consultation_question_id decidim_author_id decidim_user_group_id),
+              name: "index_question_votes_author_unique",
+              unique: true
+  end
+
+  def create_author_unique
+    remove_index :decidim_consultations_endorsements, name: "index_question_votes_author_unique"
+
+    add_index :decidim_consultations_endorsements,
+              %w(decidim_consultation_question_id decidim_author_id),
+              name: "index_question_votes_author_unique",
+              unique: true
+  end
+end

--- a/db/migrate/20200908124220_add_response_to_decidim_consultations_endorsements.decidim_consultations.rb
+++ b/db/migrate/20200908124220_add_response_to_decidim_consultations_endorsements.decidim_consultations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180131083844)
+
+class AddResponseToDecidimConsultationsEndorsements < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :decidim_consultations_endorsements,
+                  :decidim_consultations_response,
+                  foreign_key: true,
+                  index: { name: "index_consultations_endorsements_on_consultations_response_id" }
+  end
+end

--- a/db/migrate/20200908124221_rename_endorsement_to_vote.decidim_consultations.rb
+++ b/db/migrate/20200908124221_rename_endorsement_to_vote.decidim_consultations.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180201135823)
+
+class RenameEndorsementToVote < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :decidim_consultations_endorsements, :decidim_consultations_votes
+    rename_column :decidim_consultations_questions, :endorsements_count, :votes_count
+    rename_column :decidim_consultations, :start_endorsing_date, :start_voting_date
+    rename_column :decidim_consultations, :end_endorsing_date, :end_voting_date
+    rename_column :decidim_consultations_questions, :external_endorsement, :external_voting
+
+    rename_index :decidim_consultations_votes,
+                 :index_consultations_endorsements_on_author,
+                 :index_consultations_votes_on_author
+
+    rename_index :decidim_consultations_votes,
+                 :index_consultations_endorsements_on_consultation_question,
+                 :index_consultations_votes_on_consultation_question
+
+    rename_index :decidim_consultations_votes,
+                 :index_consultations_endorsements_on_consultations_response_id,
+                 :index_consultations_votes_on_consultations_response_id
+  end
+end

--- a/db/migrate/20200908124222_add_hero_image_to_decidim_consultations_question.decidim_consultations.rb
+++ b/db/migrate/20200908124222_add_hero_image_to_decidim_consultations_question.decidim_consultations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180202050920)
+
+class AddHeroImageToDecidimConsultationsQuestion < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :hero_image, :string
+    remove_column :decidim_consultations_questions, :introductory_video_url, :string
+  end
+end

--- a/db/migrate/20200908124223_add_results_published_at_to_decidim_consultations.decidim_consultations.rb
+++ b/db/migrate/20200908124223_add_results_published_at_to_decidim_consultations.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180202085309)
+
+class AddResultsPublishedAtToDecidimConsultations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations, :results_published_at, :date, index: true
+  end
+end

--- a/db/migrate/20200908124224_add_votes_count_to_decidim_consultations_response.decidim_consultations.rb
+++ b/db/migrate/20200908124224_add_votes_count_to_decidim_consultations_response.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180202133655)
+
+class AddVotesCountToDecidimConsultationsResponse < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_responses, :votes_count, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20200908124225_remove_enable_highlighted_banner_flag.decidim_consultations.rb
+++ b/db/migrate/20200908124225_remove_enable_highlighted_banner_flag.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180212100503)
+
+class RemoveEnableHighlightedBannerFlag < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :decidim_consultations, :enable_highlighted_banner, :boolean, null: false, default: true
+  end
+end

--- a/db/migrate/20200908124226_add_order_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124226_add_order_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180219092120)
+
+class AddOrderToDecidimConsultationsQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations_questions, :order, :integer, index: true
+  end
+end

--- a/db/migrate/20200908124227_add_introductory_image_to_decidim_consultations.decidim_consultations.rb
+++ b/db/migrate/20200908124227_add_introductory_image_to_decidim_consultations.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180320100658)
+
+class AddIntroductoryImageToDecidimConsultations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_consultations, :introductory_image, :string
+  end
+end

--- a/db/migrate/20200908124228_remove_unused_search_indexs.decidim_consultations.rb
+++ b/db/migrate/20200908124228_remove_unused_search_indexs.decidim_consultations.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20180712111146)
+
+class RemoveUnusedSearchIndexs < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :decidim_consultations_questions, name: "consultation_questions_title_search"
+    remove_index :decidim_consultations_questions, name: "consultation_questions_subtitle_search"
+    remove_index :decidim_consultations_questions, name: "consultation_questions_what_is_decided_search"
+    remove_index :decidim_consultations_questions, name: "consultation_question_promoter_group_search"
+    remove_index :decidim_consultations_questions, name: "consultation_question_participatory_scope_search"
+    remove_index :decidim_consultations_questions, name: "consultation_question_context_search"
+  end
+end

--- a/db/migrate/20200908124229_fix_user_groups_ids_on_consultations.decidim_consultations.rb
+++ b/db/migrate/20200908124229_fix_user_groups_ids_on_consultations.decidim_consultations.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20181003082318)
+
+class FixUserGroupsIdsOnConsultations < ActiveRecord::Migration[5.2]
+  # rubocop:disable Rails/SkipsModelValidations
+  def change
+    Decidim::UserGroup.find_each do |group|
+      old_id = group.extended_data["old_user_group_id"]
+      next unless old_id
+
+      Decidim::Consultations::Vote
+        .where(decidim_user_group_id: old_id)
+        .update_all(decidim_user_group_id: group.id)
+    end
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+end

--- a/db/migrate/20200908124230_add_options_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124230_add_options_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20190702162755)
+
+class AddOptionsToDecidimConsultationsQuestions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_consultations_questions, :max_votes, :integer
+    add_column :decidim_consultations_questions, :min_votes, :integer
+  end
+end

--- a/db/migrate/20200908124231_create_decidim_consultations_response_groups.decidim_consultations.rb
+++ b/db/migrate/20200908124231_create_decidim_consultations_response_groups.decidim_consultations.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20190708114204)
+
+class CreateDecidimConsultationsResponseGroups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_consultations_response_groups do |t|
+      t.jsonb :title
+      t.references :decidim_consultations_questions,
+                   foreign_key: true,
+                   index: { name: "index_consultations_response_groups_on_consultation_questions" }
+      t.integer :responses_count,
+                null: false,
+                default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200908124232_add_response_groups_count_to_decidim_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124232_add_response_groups_count_to_decidim_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20190708120345)
+
+class AddResponseGroupsCountToDecidimConsultationsQuestions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_consultations_questions, :response_groups_count, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20200908124233_add_response_groups_to_decidim_consultations_responses.decidim_consultations.rb
+++ b/db/migrate/20200908124233_add_response_groups_to_decidim_consultations_responses.decidim_consultations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20190708121643)
+
+class AddResponseGroupsToDecidimConsultationsResponses < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :decidim_consultations_responses,
+                  :decidim_consultations_response_group,
+                  foreign_key: true,
+                  index: { name: "index_consultations_response_groups_on_consultation_responses" }
+  end
+end

--- a/db/migrate/20200908124234_add_free_instructions_field_to_consultations_questions.decidim_consultations.rb
+++ b/db/migrate/20200908124234_add_free_instructions_field_to_consultations_questions.decidim_consultations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_consultations (originally 20190710121122)
+
+class AddFreeInstructionsFieldToConsultationsQuestions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_consultations_questions, :instructions, :jsonb
+  end
+end

--- a/db/migrate/20200908124235_create_settings.decidim_action_delegator.rb
+++ b/db/migrate/20200908124235_create_settings.decidim_action_delegator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# This migration comes from decidim_action_delegator (originally 20200824113801)
+
+class CreateSettings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :decidim_action_delegator_settings do |t|
+      t.datetime :expires_at, null: false
+      t.integer :max_grants, null: false, default: 0, limit: 2 # Maps to PostgreSQL smallint
+      t.belongs_to :decidim_consultation, null: false, foreign_key: true, index: { name: "index_decidim_settings_on_decidim_consultation_id" }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200908124236_add_setting_id_to_delegations.decidim_action_delegator.rb
+++ b/db/migrate/20200908124236_add_setting_id_to_delegations.decidim_action_delegator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# This migration comes from decidim_action_delegator (originally 20200828113755)
+
+class AddSettingIdToDelegations < ActiveRecord::Migration[5.2]
+  def change
+    add_belongs_to :decidim_action_delegator_delegations,
+                   :decidim_action_delegator_setting,
+                   null: false,
+                   foreign_key: true,
+                   index: { name: "index_decidim_delegations_on_action_delegator_setting_id" }
+  end
+end

--- a/db/migrate/20200908124237_make_granter_id_and_grantee_id_non_nullable.decidim_action_delegator.rb
+++ b/db/migrate/20200908124237_make_granter_id_and_grantee_id_non_nullable.decidim_action_delegator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# This migration comes from decidim_action_delegator (originally 20200831141540)
+
+class MakeGranterIdAndGranteeIdNonNullable < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :decidim_action_delegator_delegations, :granter_id, false
+    change_column_null :decidim_action_delegator_delegations, :grantee_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_27_094232) do
+ActiveRecord::Schema.define(version: 2020_09_08_124237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -61,14 +61,25 @@ ActiveRecord::Schema.define(version: 2020_08_27_094232) do
   end
 
   create_table "decidim_action_delegator_delegations", force: :cascade do |t|
-    t.bigint "granter_id"
-    t.bigint "grantee_id"
+    t.bigint "granter_id", null: false
+    t.bigint "grantee_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "decidim_organization_id"
+    t.bigint "decidim_action_delegator_setting_id", null: false
+    t.index ["decidim_action_delegator_setting_id"], name: "index_decidim_delegations_on_action_delegator_setting_id"
     t.index ["decidim_organization_id"], name: "index_decidim_delegations_on_decidim_organization_id"
     t.index ["grantee_id"], name: "index_decidim_action_delegator_delegations_on_grantee_id"
     t.index ["granter_id"], name: "index_decidim_action_delegator_delegations_on_granter_id"
+  end
+
+  create_table "decidim_action_delegator_settings", force: :cascade do |t|
+    t.datetime "expires_at", null: false
+    t.integer "max_grants", limit: 2, default: 0, null: false
+    t.bigint "decidim_consultation_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decidim_consultation_id"], name: "index_decidim_settings_on_decidim_consultation_id"
   end
 
   create_table "decidim_action_logs", force: :cascade do |t|
@@ -383,6 +394,102 @@ ActiveRecord::Schema.define(version: 2020_08_27_094232) do
     t.datetime "updated_at", null: false
     t.string "participatory_space_type", null: false
     t.index ["participatory_space_id", "participatory_space_type"], name: "index_decidim_components_on_decidim_participatory_space"
+  end
+
+  create_table "decidim_consultations", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "decidim_organization_id"
+    t.jsonb "title", null: false
+    t.jsonb "subtitle", null: false
+    t.jsonb "description", null: false
+    t.string "banner_image"
+    t.string "introductory_video_url"
+    t.date "start_voting_date", null: false
+    t.integer "decidim_highlighted_scope_id"
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "end_voting_date", null: false
+    t.date "results_published_at"
+    t.string "introductory_image"
+    t.index ["decidim_highlighted_scope_id"], name: "index_decidim_consultations_on_decidim_highlighted_scope_id"
+    t.index ["decidim_organization_id", "slug"], name: "index_unique_consultation_slug_and_organization", unique: true
+    t.index ["decidim_organization_id"], name: "index_decidim_consultations_on_decidim_organization_id"
+    t.index ["description"], name: "decidim_consultations_description_search"
+    t.index ["published_at"], name: "index_decidim_consultations_on_published_at"
+    t.index ["subtitle"], name: "decidim_consultations_subtitle_search"
+    t.index ["title"], name: "decidim_consultations_title_search"
+  end
+
+  create_table "decidim_consultations_questions", force: :cascade do |t|
+    t.bigint "decidim_consultation_id"
+    t.bigint "decidim_scope_id"
+    t.jsonb "title", null: false
+    t.jsonb "subtitle", null: false
+    t.jsonb "what_is_decided", null: false
+    t.jsonb "promoter_group", null: false
+    t.jsonb "participatory_scope", null: false
+    t.jsonb "question_context"
+    t.string "banner_image"
+    t.string "reference"
+    t.string "hashtag"
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "decidim_organization_id", null: false
+    t.string "slug", null: false
+    t.integer "votes_count", default: 0, null: false
+    t.jsonb "origin_scope"
+    t.jsonb "origin_title"
+    t.string "origin_url"
+    t.string "i_frame_url"
+    t.boolean "external_voting"
+    t.integer "responses_count", default: 0, null: false
+    t.string "hero_image"
+    t.integer "order"
+    t.integer "max_votes"
+    t.integer "min_votes"
+    t.integer "response_groups_count", default: 0, null: false
+    t.jsonb "instructions"
+    t.index ["decidim_consultation_id"], name: "index_consultations_questions_on_consultation_id"
+    t.index ["decidim_organization_id", "slug"], name: "index_unique_question_slug_and_organization", unique: true
+    t.index ["decidim_scope_id"], name: "index_decidim_consultations_questions_on_decidim_scope_id"
+    t.index ["origin_scope"], name: "consultation_questions_origin_scope_search"
+    t.index ["origin_title"], name: "consultation_questions_origin_title_search"
+    t.index ["published_at"], name: "index_decidim_consultations_questions_on_published_at"
+  end
+
+  create_table "decidim_consultations_response_groups", force: :cascade do |t|
+    t.jsonb "title"
+    t.bigint "decidim_consultations_questions_id"
+    t.integer "responses_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decidim_consultations_questions_id"], name: "index_consultations_response_groups_on_consultation_questions"
+  end
+
+  create_table "decidim_consultations_responses", force: :cascade do |t|
+    t.jsonb "title"
+    t.bigint "decidim_consultations_questions_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "votes_count", default: 0, null: false
+    t.bigint "decidim_consultations_response_group_id"
+    t.index ["decidim_consultations_questions_id"], name: "index_consultations_responses_on_consultation_questions"
+    t.index ["decidim_consultations_response_group_id"], name: "index_consultations_response_groups_on_consultation_responses"
+  end
+
+  create_table "decidim_consultations_votes", force: :cascade do |t|
+    t.bigint "decidim_consultation_question_id"
+    t.bigint "decidim_author_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "decidim_user_group_id"
+    t.bigint "decidim_consultations_response_id"
+    t.index ["decidim_author_id"], name: "index_consultations_votes_on_author"
+    t.index ["decidim_consultation_question_id", "decidim_author_id", "decidim_user_group_id"], name: "index_question_votes_author_unique", unique: true
+    t.index ["decidim_consultation_question_id"], name: "index_consultations_votes_on_consultation_question"
+    t.index ["decidim_consultations_response_id"], name: "index_consultations_votes_on_consultations_response_id"
   end
 
   create_table "decidim_content_blocks", force: :cascade do |t|
@@ -1351,7 +1458,9 @@ ActiveRecord::Schema.define(version: 2020_08_27_094232) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "decidim_action_delegator_delegations", "decidim_action_delegator_settings"
   add_foreign_key "decidim_action_delegator_delegations", "decidim_organizations"
+  add_foreign_key "decidim_action_delegator_settings", "decidim_consultations"
   add_foreign_key "decidim_area_types", "decidim_organizations"
   add_foreign_key "decidim_areas", "decidim_area_types", column: "area_type_id"
   add_foreign_key "decidim_areas", "decidim_organizations"
@@ -1359,6 +1468,10 @@ ActiveRecord::Schema.define(version: 2020_08_27_094232) do
   add_foreign_key "decidim_attachments", "decidim_attachment_collections", column: "attachment_collection_id", name: "fk_decidim_attachments_attachment_collection_id", on_delete: :nullify
   add_foreign_key "decidim_authorizations", "decidim_users"
   add_foreign_key "decidim_categorizations", "decidim_categories"
+  add_foreign_key "decidim_consultations_response_groups", "decidim_consultations_questions", column: "decidim_consultations_questions_id"
+  add_foreign_key "decidim_consultations_responses", "decidim_consultations_questions", column: "decidim_consultations_questions_id"
+  add_foreign_key "decidim_consultations_responses", "decidim_consultations_response_groups"
+  add_foreign_key "decidim_consultations_votes", "decidim_consultations_responses"
   add_foreign_key "decidim_identities", "decidim_organizations"
   add_foreign_key "decidim_newsletters", "decidim_users", column: "author_id"
   add_foreign_key "decidim_participatory_process_steps", "decidim_participatory_processes"


### PR DESCRIPTION
Namely https://github.com/coopdevs/decidim-module-action_delegator/pull/6.

For this to work, we also add the migrations from the `decidim_consultations` gem plus the ones `decidim_action_delegator` added.