### PR TITLE
Switch web process from Passenger to Puma

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec passenger start -p ${PORT:-3000} --max-pool-size ${WEB_CONCURRENCY:-5}
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 worker: bundle exec sidekiq -e ${RACK_ENV:-development} -C config/sidekiq.yml
 release: bundle exec rake db:migrate


### PR DESCRIPTION
Related to https://github.com/codegram/decidim-deploy-heroku/pull/10. We started with the default app server Codegram configured back in the day but this is old now.

https://github.com/codegram/decidim-deploy-heroku/issues/8 has all the details.