### PR TITLE
Remove Decidim Heroku deploy gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,6 @@ group :development do
   gem "spring", "~> 2.0"
   gem "spring-watcher-listen", "~> 2.0"
   gem "web-console", "~> 3.5"
-
-  gem "decidim-deploy-heroku", git: "https://github.com/codegram/decidim-deploy-heroku.git"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,6 @@ GIT
       decidim-admin (= 0.21.0)
       decidim-core (= 0.21.0)
 
-GIT
-  remote: https://github.com/codegram/decidim-deploy-heroku.git
-  revision: 2684552cf7b2d5845043d5c5bbd41faacc07aa3b
-  specs:
-    decidim-deploy-heroku (0.0.1)
-      decidim (~> 0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -805,7 +798,6 @@ DEPENDENCIES
   decidim (= 0.21.0)
   decidim-action_delegator!
   decidim-consultations (= 0.21.0)
-  decidim-deploy-heroku!
   decidim-dev (= 0.21.0)
   faker (~> 1.9)
   fog-aws


### PR DESCRIPTION
This gem it provides only the `decidim:deploy:heroku_installer` generator which configures the app to run in Heroku. Their docs states it clearly:

```
Once the last command is performed you can uninstall the gem by removing it from the Gemfile and rerun bundle install.
```