### PR TITLE
Fetch direct_verifications from upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "decidim", "0.21.0"
 gem "decidim-consultations", "0.21.0"
 
 gem "decidim-action_delegator", github: "coopdevs/decidim-module-action_delegator"
-gem "decidim-direct_verifications", github: "coopdevs/decidim-verifications-direct_verifications", branch: "read-multiple-columns"
+gem "decidim-direct_verifications", github: "Platoniq/decidim-verifications-direct_verifications", branch: "devel"
 
 gem "bootsnap", "~> 1.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: git://github.com/Platoniq/decidim-verifications-direct_verifications.git
+  revision: ad8c6c02fe0b5ffc27977361ec047420ca845b92
+  branch: devel
+  specs:
+    decidim-direct_verifications (0.20)
+      decidim-admin (>= 0.17.0)
+      decidim-core (>= 0.17.0)
+
+GIT
   remote: git://github.com/coopdevs/decidim-module-action_delegator.git
   revision: 8e19825dcf5d972f2598a9203bbebcba44b24235
   specs:
@@ -6,15 +15,6 @@ GIT
       decidim-admin (= 0.21.0)
       decidim-consultations (= 0.21.0)
       decidim-core (= 0.21.0)
-
-GIT
-  remote: git://github.com/coopdevs/decidim-verifications-direct_verifications.git
-  revision: d5deb11eee87b805a8f0dc181dc90fcc069a4278
-  branch: read-multiple-columns
-  specs:
-    decidim-direct_verifications (0.20)
-      decidim-admin (>= 0.17.0)
-      decidim-core (>= 0.17.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
We fetch them from `devel` aka. develop, because that's where our PRs get merged before a release is published.