### PR TITLE
Install missing migrations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,10 @@ jobs:
       - run: |
           bundle update decidim-action_delegator
 
+      - run: |
+          bundle exec rails decidim_action_delegator:install:migrations
+
       - uses: EndBug/add-and-commit@v5
         with:
-          add: Gemfile.lock
+          add: Gemfile.lock db/migrate
           branch: master

--- a/db/migrate/20201013142129_remove_expires_at_from_delegations.decidim_action_delegator.rb
+++ b/db/migrate/20201013142129_remove_expires_at_from_delegations.decidim_action_delegator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_action_delegator (originally 20201001172345)
+
+class RemoveExpiresAtFromDelegations < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :decidim_action_delegator_settings, :expires_at
+  end
+end

--- a/db/migrate/20201013142130_add_setting_granter_unique_index_to_delegations.decidim_action_delegator.rb
+++ b/db/migrate/20201013142130_add_setting_granter_unique_index_to_delegations.decidim_action_delegator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# This migration comes from decidim_action_delegator (originally 20201005203554)
+
+class AddSettingGranterUniqueIndexToDelegations < ActiveRecord::Migration[5.2]
+  def change
+    add_index :decidim_action_delegator_delegations,
+              [:decidim_action_delegator_setting_id, :granter_id],
+              unique: true,
+              name: "index_unique_decidim_delegations_on_setting_id_granter_id"
+  end
+end

--- a/db/migrate/20201013142131_remove_setting_id_index_from_delegations.decidim_action_delegator.rb
+++ b/db/migrate/20201013142131_remove_setting_id_index_from_delegations.decidim_action_delegator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_action_delegator (originally 20201006084522)
+
+class RemoveSettingIdIndexFromDelegations < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :decidim_action_delegator_delegations, name: "index_decidim_delegations_on_action_delegator_setting_id"
+  end
+end


### PR DESCRIPTION
This is obviously causing issues because the code doesn't match the columns present in the DB. I also took the chance to automate this so it doesn't happen again. If the latest version of action_delegator has any migration we will commit them. We got so used to this continuous delivery set up that we forget to install them because it requires manual intervention.