### PR TITLE
Configure Carrierwave to use Blackblaze storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ end
 
 group :production do
   gem 'dalli'
+  gem 'fog-aws'
   gem 'lograge'
   gem 'sentry-raven'
   gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,7 @@ GEM
     erubi (1.9.0)
     etherpad-lite (0.3.0)
       rest-client (>= 1.6)
+    excon (0.78.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -395,6 +396,23 @@ GEM
     file_validators (2.3.0)
       activemodel (>= 3.2)
       mime-types (>= 1.0)
+    fog-aws (3.6.7)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.3)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     foundation-rails (6.4.3.0)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
@@ -441,6 +459,7 @@ GEM
     ice_nine (0.11.2)
     invisible_captcha (0.13.0)
       rails (>= 3.2.0)
+    ipaddress (0.8.3)
     jaro_winkler (1.5.4)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -785,6 +804,7 @@ DEPENDENCIES
   decidim-dev (= 0.21.0)
   decidim-direct_verifications!
   faker (~> 1.9)
+  fog-aws
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   lograge

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -9,23 +9,25 @@ CarrierWave.configure do |config|
   config.enable_processing = !Rails.env.test?
 end
 
-# Setup CarrierWave to use Amazon S3. Add `gem "fog-aws" to your Gemfile.
-#
-# CarrierWave.configure do |config|
-#   config.storage = :fog
-#   config.fog_provider = 'fog/aws'                                             # required
-#   config.fog_credentials = {
-#     provider:              'AWS',                                             # required
-#     aws_access_key_id:     Rails.application.secrets.aws_access_key_id,     # required
-#     aws_secret_access_key: Rails.application.secrets.aws_secret_access_key, # required
-#     region:                'eu-west-1',                                       # optional, defaults to 'us-east-1'
-#     host:                  's3.example.com',                                  # optional, defaults to nil
-#     endpoint:              'https://s3.example.com:8080'                      # optional, defaults to nil
-#   }
-#   config.fog_directory  = 'name_of_directory'                                 # required
-#   config.fog_public     = false                                               # optional, defaults to true
-#   config.fog_attributes = {
-#     'Cache-Control' => "max-age=#{365.day.to_i}",
-#     'X-Content-Type-Options' => "nosniff"
-#   }
-# end
+# Although we use Backblaze's B2 as object storage for assets, we use its S3's compatible API. We
+# briefly tried the `fog-backblaze` gem but things didn't seem to work at first.
+if Rails.application.secrets.backblaze[:access_key_id].present?
+  require 'carrierwave/storage/fog'
+
+  CarrierWave.configure do |config|
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: Rails.application.secrets.backblaze[:access_key_id],
+      aws_secret_access_key: Rails.application.secrets.backblaze[:secret_access_key],
+      endpoint: 'https://s3.us-west-001.backblazeb2.com'
+    }
+    config.fog_directory  = 'cercles-coop-production'
+    config.fog_public     = true
+    config.fog_attributes = {
+      'Cache-Control' => "max-age=#{365.day.to_i}",
+      'X-Content-Type-Options' => 'nosniff'
+    }
+  end
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -72,3 +72,6 @@ production:
   smtp_starttls_auto: true
   smtp_authentication: "plain"
   sentry_enabled: true
+  backblaze:
+    access_key_id: <%= ENV["B2_ACCESS_KEY_ID"] %>
+    secret_access_key: <%= ENV["B2_SECRET_ACCESS_KEY"] %>


### PR DESCRIPTION
This makes Carrierwave, the asset storage library Decidim uses, with Backblaze's B2 cloud storage. It took me a while to realize that Decidim doesn't use Active Storage. It didn't exist when Decidim started.

I had a bit of trouble configuring it though. Going through Fog AWS I realized that `:endpoint` is just an alternative to providing `:host`, `:scheme` and `:port`.

It must be that the `@endpoint` set in fog-aws-3.6.7/lib/fog/aws/storage.rb is used elsewhere because replacing `:endpoint` with these other config vars doesn't work, although their equivalent ivars do end up with the same value.