### PR TITLE
Force clients to use HTTPS

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = ENV.fetch("FORCE_SSL", false)
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
We are running on the free plan in staging and we don't have an SSL cert. This lets us force HTTPS at will without coupling to the environment name or host.