### PR TITLE
Configure Backblaze for staging

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -23,7 +23,7 @@ if Rails.application.secrets.dig(:backblaze, :access_key_id).present?
       aws_secret_access_key: Rails.application.secrets.backblaze[:secret_access_key],
       endpoint: 'https://s3.us-west-001.backblazeb2.com'
     }
-    config.fog_directory  = 'cercles-coop-production'
+    config.fog_directory  = Rails.application.secrets.backblaze[:bucket_name]
     config.fog_public     = true
     config.fog_attributes = {
       'Cache-Control' => "max-age=#{365.day.to_i}",

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -75,3 +75,4 @@ production:
   backblaze:
     access_key_id: <%= ENV["B2_ACCESS_KEY_ID"] %>
     secret_access_key: <%= ENV["B2_SECRET_ACCESS_KEY"] %>
+    bucket_name: <%= ENV["B2_BUCKET_NAME"] %>


### PR DESCRIPTION
This enables us to provide a specific Backblaze B2 bucket for staging, along with its separate credentials.