### PR TITLE
Timeout requests that take longer than 15s

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "decidim-direct_verifications", github: "Platoniq/decidim-verifications-dire
 gem "bootsnap", "~> 1.3"
 
 gem "puma", "~> 4.3.3"
+gem "rack-timeout"
 gem "uglifier", "~> 4.1"
 
 gem "faker", "~> 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,6 +599,7 @@ GEM
       rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-timeout (0.6.0)
     rails (5.2.4.4)
       actioncable (= 5.2.4.4)
       actionmailer (= 5.2.4.4)
@@ -839,6 +840,7 @@ DEPENDENCIES
   listen (~> 3.1)
   lograge
   puma (~> 4.3.3)
+  rack-timeout
   sentry-raven
   sidekiq
   spring (~> 2.0)


### PR DESCRIPTION
This installs rack-timeout to prevent requests from taking longer than 15s. This will also prevent requests timed-out by Heroku's router to end up "stacking" even though they can't be responded to.

More details: https://devcenter.heroku.com/articles/h12-request-timeout-in-ruby-mri