### PR TITLE
Expire invitations after one month

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Devise.setup do |config|
+  config.invite_for = 1.month
+end


### PR DESCRIPTION
This extends the time-window so that invitations are still valid when the general assembly starts. They are legally called between a month and 15 days before.