### PR TITLE
Read LOG_LEVEL env var or default to :debug

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV.fetch("LOG_LEVEL", "debug").to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
This enables to define the log level on demand. Currently, debug is generating high volume of logs and only ~30min fit into Heroku's limits.

We went with Coralogix as log management add-on (they have a trial plus freemium) but we want to have this ENV var as a fallback. Reducing the volume will let us fit more into the 1500-lines limit.