### PR TITLE
Enable Cache-Control to serve assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,6 +32,9 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=31536000'
+  }
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(:harmony => true)


### PR DESCRIPTION
This will reduce traffic to the app as most of the assets aren't changed. None of the assets served by Rails (remember we are in Heroku and there's no Nginx in front of it) are cached.