### PR TITLE
Add Rails Autoscale gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "bootsnap", "~> 1.3"
 
 gem "puma", "~> 4.3.3"
 gem "rack-timeout"
+gem "rails_autoscale_agent"
 gem "uglifier", "~> 4.1"
 
 gem "faker", "~> 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -641,6 +641,7 @@ GEM
     rails-i18n (5.1.3)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
+    rails_autoscale_agent (0.9.1)
     railties (5.2.4.4)
       actionpack (= 5.2.4.4)
       activesupport (= 5.2.4.4)
@@ -861,6 +862,7 @@ DEPENDENCIES
   lograge
   puma (~> 4.3.3)
   rack-timeout
+  rails_autoscale_agent
   sentry-raven
   sidekiq
   spring (~> 2.0)


### PR DESCRIPTION
This is necessary to use https://railsautoscale.com/ and have our dyno count increase based on request queueing and handle assembly with decent response times.