### PR TITLE
Install scout apm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "bootsnap", "~> 1.3"
 
 gem "puma", "~> 4.3.3"
 gem "rack-timeout"
-gem "rails_autoscale_agent"
 gem "uglifier", "~> 4.1"
 
 gem "faker", "~> 1.9"
@@ -43,4 +42,5 @@ group :production do
   gem 'sidekiq'
   gem 'barnes'
   gem 'scout_apm'
+  gem 'rails_autoscale_agent'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -42,4 +42,5 @@ group :production do
   gem 'sentry-raven'
   gem 'sidekiq'
   gem 'barnes'
+  gem 'scout_apm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -747,6 +747,8 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
+    scout_apm (2.6.10)
+      parser
     searchlight (4.1.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -863,6 +865,7 @@ DEPENDENCIES
   puma (~> 4.3.3)
   rack-timeout
   rails_autoscale_agent
+  scout_apm
   sentry-raven
   sidekiq
   spring (~> 2.0)


### PR DESCRIPTION
Scout seems to provide Request Queueing time which is what we need to assess the right settings for Rails autoscaling which we introduced in #61.

It's not clear to me if the free tier includes this. We'll give a try and see how much we can get from it.