### PR TITLE
Set public cache-control to object storage reqs

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -26,7 +26,7 @@ if Rails.application.secrets.dig(:backblaze, :access_key_id).present?
     config.fog_directory  = Rails.application.secrets.backblaze[:bucket_name]
     config.fog_public     = true
     config.fog_attributes = {
-      'Cache-Control' => "max-age=#{365.day.to_i}",
+      'Cache-Control' => "public, max-age=#{365.day.to_i}",
       'X-Content-Type-Options' => 'nosniff'
     }
   end


### PR DESCRIPTION
We are setting the age but not specifically allowing caches to store the response. This may be confusing for browsers because, in Chrome, I still see the content download in assets requests. Hopefully, this directive will fix it.