### PR TITLE
Point out our own stable 0.22 with extra fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 ruby RUBY_VERSION
 
-DECIDIM_VERSION = { github: "coopdevs/decidim", branch: "fix/consultation-description-rich-text" }
+DECIDIM_VERSION = { github: "coopdevs/decidim", branch: "0.22-stable-plus-fixes" }
 
 gem "decidim", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GIT
 GIT
   remote: git://github.com/coopdevs/decidim.git
   revision: fc95f75a5055be829d31bfc793036f29c26476bb
-  branch: fix/consultation-description-rich-text
+  branch: 0.22-stable-plus-fixes
   specs:
     decidim (0.22.0)
       decidim-accountability (= 0.22.0)
@@ -546,7 +546,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-shellout (3.1.7)
+    mixlib-shellout (3.2.2)
       chef-utils
     msgpack (1.2.10)
     multi_json (1.15.0)
@@ -591,7 +591,7 @@ GEM
     paper_trail (10.3.1)
       activerecord (>= 4.2)
       request_store (~> 1.1)
-    parallel (1.19.2)
+    parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (1.1.4)
@@ -832,7 +832,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.9.4)
+    webmock (3.10.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)


### PR DESCRIPTION
Using the same branch for both suggesting a fix to upstream and pointing to it in production is becoming a dangerous mess. I'm doing/undoing changes and rewriting the git history but I don't want to risk introducing regressions in production.

Once that patch is merged we can consider dropping our stable branch. Meanwhile, we better off keep things decoupled.