### PR TITLE
Remove broken CI workflow step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set env
-        run: echo ::set-env name=workspace::$GITHUB_WORKSPACE
-
       - uses: ruby/setup-ruby@master
         with:
           ruby-version: ${{ env.RUBY_VERSION }}


### PR DESCRIPTION
This fails with

```
Error: Unable to process command '::set-env name=workspace::/home/runner/work/decidim-coopcat/decidim-coopcat' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

but it doesn't seem to be used or needed.