### PR TITLE
Add French to the list of available locales

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -6,7 +6,7 @@ Decidim.configure do |config|
 
   # Change these lines to set your preferred locales
   config.default_locale = :ca
-  config.available_locales = [:en, :ca, :es]
+  config.available_locales = [:en, :ca, :es, :fr]
 
   # Geocoder configuration
   # config.geocoder = {


### PR DESCRIPTION
We can enable it for organizations from the console by running

```rb
organization = Decidim::Organization.find_by(host: 'xxx')
organization.available_locales << "fr"
organization.save
```