### PR TITLE
Batch processing PoC

### DIFF
--- a/app/jobs/dummy_batch.rb
+++ b/app/jobs/dummy_batch.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class DummyBatch < ApplicationJob
+  queue_as :default
+
+  before_perform :persist_batch
+
+  def perform
+    2.times do
+      DummyJob.perform_later(batch.id)
+    end
+  end
+
+  private
+
+  attr_reader :batch
+
+  def persist_batch
+    puts "  => Persisting batch"
+    @batch = Batch.create!(job_id: job_id)
+  end
+end

--- a/app/jobs/dummy_callback.rb
+++ b/app/jobs/dummy_callback.rb
@@ -1,0 +1,29 @@
+class DummyCallback < ApplicationJob
+  queue_as :default
+
+  after_perform :tear_down
+
+  def perform(batch_id)
+    @batch_id = batch_id
+
+    puts "  => Batch successfully executed"
+    puts "  => Notifying user..."
+  end
+
+  private
+
+  attr_reader :batch_id
+
+  def tear_down
+    update_batch unless batch_finished?
+    puts "  => Statuses cleaned up"
+  end
+
+  def batch_finished?
+    Batch.where(id: batch_id, finished_at: nil).exists?
+  end
+
+  def update_batch
+    Batch.where(id: batch_id).update_all(finished_at: Time.zone.now)
+  end
+end

--- a/app/jobs/dummy_job.rb
+++ b/app/jobs/dummy_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class DummyJob < ApplicationJob
+  queue_as :default
+
+  after_enqueue :persist_job
+  after_perform :tear_down
+
+  def perform(batch_id)
+    @batch_id = batch_id
+  end
+
+  private
+
+  attr_reader :batch_id
+
+  def persist_job
+    puts "  => Persisting initial state of job #{job_id}"
+    create_job_status
+  end
+
+  def tear_down
+    puts "  => Persisting end state of job #{job_id}"
+
+    update_job_status
+    execute_callback if all_jobs_processed?
+  end
+
+  def all_jobs_processed?
+    puts "  => #{remaining.count} jobs remaining"
+    remaining.count.zero?
+  end
+
+  def remaining
+    @remaining ||= BackgroundJob.where(status: "enqueued")
+  end
+
+  def create_job_status
+    BackgroundJob.create(job_id: job_id, batch_id: batch_id, status: "enqueued")
+  end
+
+  def update_job_status
+    BackgroundJob.where(job_id: job_id).update_all(status: "success")
+  end
+
+  def execute_callback
+    DummyCallback.perform_later(batch_id)
+  end
+end

--- a/app/models/background_job.rb
+++ b/app/models/background_job.rb
@@ -1,0 +1,2 @@
+class BackgroundJob < ApplicationRecord
+end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,0 +1,3 @@
+class Batch < ApplicationRecord
+  has_many :background_jobs
+end

--- a/db/migrate/20210324152217_create_background_jobs.rb
+++ b/db/migrate/20210324152217_create_background_jobs.rb
@@ -1,0 +1,12 @@
+class CreateBackgroundJobs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :background_jobs do |t|
+      t.string :status
+      t.datetime :finished_at
+      t.string :job_id
+      t.belongs_to :batch
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210324161755_create_batches.rb
+++ b/db/migrate/20210324161755_create_batches.rb
@@ -1,0 +1,10 @@
+class CreateBatches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :batches do |t|
+      t.datetime :finished_at
+      t.string :job_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_120245) do
+ActiveRecord::Schema.define(version: 2021_03_24_161755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -36,6 +36,23 @@ ActiveRecord::Schema.define(version: 2021_02_11_120245) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "background_jobs", force: :cascade do |t|
+    t.string "status"
+    t.datetime "finished_at"
+    t.string "job_id"
+    t.bigint "batch_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["batch_id"], name: "index_background_jobs_on_batch_id"
+  end
+
+  create_table "batches", force: :cascade do |t|
+    t.datetime "finished_at"
+    t.string "job_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "decidim_accountability_results", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This is just opened as a proof of concept about how a quick and simple Active Job Batch processing would look like. See https://github.com/Platoniq/decidim-verifications-direct_verifications/issues/3 for context. It's not meant to be merged, just a demo.

## Log output

Note log lines are not in order of execution.

```rb
irb(main):018:0> DummyBatch.perform_later
Enqueued DummyBatch (Job ID: da0a831f-4fe5-4e35-bc9e-54034bf9ca15) to Async(default)
=> #<DummyBatch:0x00005644d90a7e80 @arguments=[], @job_id="da0a831f-4fe5-4e35-bc9e-54034bf9ca15", @queue_name="default", @priority=nil, @executions=0, @provider_job_id="ccd3221c-0ebf-4d2c-9fae-6741123d3994">
irb(main):019:0> Performing DummyBatch (Job ID: da0a831f-4fe5-4e35-bc9e-54034bf9ca15) from Async(default)
  => Persisting batch
   (0.7ms)  BEGIN
  Batch Create (1.2ms)  INSERT INTO "batches" ("job_id", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"  [["job_id", "da0a831f-4fe5-4e35-bc9e-54034bf9ca15"], ["created_at", "2021-03-24 17:05:47.366996"], ["updated_at", "2021-03-24 17:05:47.366996"]]
   (1.8ms)  COMMIT  => Persisting initial state of job 1e420def-16a5-47f4-b0be-8e08b8345211Performing DummyJob (Job ID: 1e420def-16a5-47f4-b0be-8e08b8345211) from Async(default) with arguments: 26
  => Persisting end state of job 1e420def-16a5-47f4-b0be-8e08b8345211
   (0.3ms)  BEGIN  BackgroundJob Create (0.6ms)  INSERT INTO "background_jobs" ("status", "job_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"  [["status", "enqueued"], ["job_id", "1e420def-16a5-47f4-b0be-8e08b8345211"], ["created_at", "2021-03-24 17:05:47.395400"], ["updated_at", "2021-03-24 17:05:47.395400"]]
  BackgroundJob Update All (0.8ms)  UPDATE "background_jobs" SET "status" = 'success' WHERE "background_jobs"."job_id" = $1  [["job_id", "1e420def-16a5-47f4-b0be-8e08b8345211"]]   (0.5ms)  SELECT COUNT(*) FROM "background_jobs" WHERE "background_jobs"."status" = $1  [["status", "enqueued"]]   (1.5ms)  COMMIT
  => 0 jobs remaining
  CACHE  (0.0ms)  SELECT COUNT(*) FROM "background_jobs" WHERE "background_jobs"."status" = $1  [["status", "enqueued"]]Enqueued DummyJob (Job ID: 1e420def-16a5-47f4-b0be-8e08b8345211) to Async(default) with arguments: 26  => Persisting initial state of job b2dbcfdd-4f6b-4e91-8cd4-f0c696506ed7
   (0.3ms)  BEGINPerforming DummyJob (Job ID: b2dbcfdd-4f6b-4e91-8cd4-f0c696506ed7) from Async(default) with arguments: 26  => Persisting end state of job b2dbcfdd-4f6b-4e91-8cd4-f0c696506ed7
  BackgroundJob Create (0.5ms)  INSERT INTO "background_jobs" ("status", "job_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"  [["status", "enqueued"], ["job_id", "b2dbcfdd-4f6b-4e91-8cd4-f0c696506ed7"], ["created_at", "2021-03-24 17:05:47.400349"], ["updated_at", "2021-03-24 17:05:47.400349"]]
   (1.1ms)  COMMIT
Enqueued DummyJob (Job ID: b2dbcfdd-4f6b-4e91-8cd4-f0c696506ed7) to Async(default) with arguments: 26
Performed DummyBatch (Job ID: da0a831f-4fe5-4e35-bc9e-54034bf9ca15) from Async(default) in 66.67ms
Enqueued DummyCallback (Job ID: 9514e9f4-81cb-4fcf-a707-d01931c92125) to Async(default) with arguments: 26
Performed DummyJob (Job ID: 1e420def-16a5-47f4-b0be-8e08b8345211) from Async(default) in 21.22ms
Performing DummyCallback (Job ID: 9514e9f4-81cb-4fcf-a707-d01931c92125) from Async(default) with arguments: 26
  => Batch successfully executed
  => Notifying user...
  Batch Exists (0.3ms)  SELECT  1 AS one FROM "batches" WHERE "batches"."id" = $1 AND "batches"."finished_at" IS NULL LIMIT $2  [["id", 26], ["LIMIT", 1]]
  => Statuses cleaned up
Performed DummyCallback (Job ID: 9514e9f4-81cb-4fcf-a707-d01931c92125) from Async(default) in 1.24ms
  BackgroundJob Update All (1.7ms)  UPDATE "background_jobs" SET "status" = 'success' WHERE "background_jobs"."job_id" = $1  [["job_id", "b2dbcfdd-4f6b-4e91-8cd4-f0c696506ed7"]]
   (0.4ms)  SELECT COUNT(*) FROM "background_jobs" WHERE "background_jobs"."status" = $1  [["status", "enqueued"]]
  => 1 jobs remaining
  CACHE  (0.0ms)  SELECT COUNT(*) FROM "background_jobs" WHERE "background_jobs"."status" = $1  [["status", "enqueued"]]
Performed DummyJob (Job ID: b2dbcfdd-4f6b-4e91-8cd4-f0c696506ed7) from Async(default) in 14.8ms
```