### PR TITLE
Remove Rails autoscaling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :production do
   gem 'fog-aws'
   gem 'lograge'
   gem 'rack-timeout'
-  gem 'rails_autoscale_agent'
   gem 'scout_apm'
   gem 'sentry-raven'
   gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -646,7 +646,6 @@ GEM
     rails-i18n (5.1.3)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
-    rails_autoscale_agent (0.10.2)
     railties (5.2.4.5)
       actionpack (= 5.2.4.5)
       activesupport (= 5.2.4.5)
@@ -872,7 +871,6 @@ DEPENDENCIES
   lograge
   puma (~> 5.2.2)
   rack-timeout
-  rails_autoscale_agent
   scout_apm
   sentry-raven
   sidekiq


### PR DESCRIPTION
We've proven that 2 app servers are enough to hold all the traffic. We do experience ~300ms request queueing on one or two requests after a deployment but that's nothing an extra app server solves.