### PR TITLE
Move Faker to dev and test groups only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,12 +18,11 @@ gem "bootsnap", "~> 1.7"
 gem "puma", "~> 5.3.2"
 gem "uglifier", "~> 4.1"
 
-gem "faker", "~> 2.18"
-
 group :development, :test do
   gem "byebug", "~> 11.1", platform: :mri
 
   gem "decidim-dev", DECIDIM_VERSION
+  gem "faker", "~> 2.18"
 end
 
 group :development do


### PR DESCRIPTION
This gem wastes a bit of memory in staging and production, according to https://github.com/schneems/derailed_benchmarks#memory-used-at-require-time:

```
$ bundle exec derailed bundle:mem
TOP: 90.1406 MiB
  decidim: 50.1211 MiB
  (...)
    faker: 2.0703 MiB
```