### PR TITLE
Change Sentry setup to match current docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :production do
   gem 'lograge'
   gem 'rack-timeout'
   gem 'scout_apm'
-  gem 'sentry-raven'
+  gem 'sentry-ruby'
+  gem 'sentry-rails'
   gem 'sidekiq'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -781,8 +781,16 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.1.2)
+    sentry-rails (4.5.0)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.5.0)
+    sentry-ruby (4.5.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.5.0)
+    sentry-ruby-core (4.5.0)
+      concurrent-ruby
+      faraday
     seven_zip_ruby (1.3.0)
     sidekiq (6.2.1)
       connection_pool (>= 2.2.2)
@@ -900,7 +908,8 @@ DEPENDENCIES
   puma (~> 5.3.2)
   rack-timeout
   scout_apm
-  sentry-raven
+  sentry-rails
+  sentry-ruby
   sidekiq
   spring (~> 2.1)
   spring-watcher-listen (~> 2.0)


### PR DESCRIPTION
I was just trying to raise an error from a Rails console but Ruby raises

```
NameError (uninitialized constant Sentry)
```

That's weird because at this point it should be defined. Likewise, manually calling `raise` doesn't show up in Sentry either.

Hopefully, updating the setup to what's documented in https://docs.sentry.io/platforms/ruby/guides/rails/. May fix this an
other potentially missed errors.