### PR TITLE
Configure Sentry from an initializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,5 +45,6 @@ group :production do
   gem 'scout_apm'
   gem 'sentry-ruby'
   gem 'sentry-rails'
+  gem 'sentry-sidekiq'
   gem 'sidekiq'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -786,6 +786,8 @@ GEM
     sentry-ruby-core (4.5.1)
       concurrent-ruby
       faraday
+    sentry-sidekiq (4.5.1)
+      sentry-ruby-core (~> 4.5.0)
     seven_zip_ruby (1.3.0)
     sidekiq (6.2.1)
       connection_pool (>= 2.2.2)
@@ -906,6 +908,7 @@ DEPENDENCIES
   scout_apm
   sentry-rails
   sentry-ruby
+  sentry-sidekiq
   sidekiq
   spring (~> 2.1)
   spring-watcher-listen (~> 2.0)

--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -7,8 +7,9 @@ class DecidimController < ApplicationController
   private
 
   def set_raven_context
-    return unless Rails.application.secrets.sentry_enabled?
-    Raven.user_context({id: try(:current_user).try(:id)}.merge(session))
-    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+    return unless Rails.application.secrets.sentry_enabled
+
+    Sentry.set_user({id: try(:current_user).try(:id)}.merge(session))
+    Sentry.set_extras(params: params.to_unsafe_h, url: request.url)
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,6 @@
+if Rails.application.secrets.sentry_enabled
+  Sentry.init do |config|
+    config.dsn = ENV['SENTRY_DSN']
+    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  end
+end


### PR DESCRIPTION
It seems that since https://github.com/coopdevs/decidim-coopcat/pull/146 (I have no actual proof) no errors are being reported.

I noticed that the DSN wasn't matching the one shown in Sentry's settings but that wasn't enough. Calling `init` manually may fix it.